### PR TITLE
Fix: Update column name from TIME to DATE

### DIFF
--- a/src/psx/web.py
+++ b/src/psx/web.py
@@ -17,7 +17,7 @@ from pdb import set_trace
 
 class DataReader:
 
-    headers = ['TIME', 'OPEN', 'HIGH', 'LOW', 'CLOSE', 'VOLUME']
+    headers = ['DATE', 'OPEN', 'HIGH', 'LOW', 'CLOSE', 'VOLUME']
 
     def __init__(self):
         self.__history = "https://dps.psx.com.pk/historical"
@@ -78,11 +78,11 @@ class DataReader:
             cols = [col.getText() for col in row.select("td")]
         
             for key, value in zip(self.headers, cols):
-                if key == "TIME":
+                if key == "DATE":
                     value = datetime.strptime(value, "%b %d, %Y")
                 stocks[key].append(value)
 
-        return pd.DataFrame(stocks, columns=self.headers).set_index("TIME")
+        return pd.DataFrame(stocks, columns=self.headers).set_index("DATE")
 
     def daterange(self, start: date, end: date) -> list:
         period = end - start


### PR DESCRIPTION
## Problem
The PSX website changed the date column name from "TIME" to "DATE", causing the library to fail with the error:
`"None of ['TIME'] are in the columns"`

## Solution
Updated all references from "TIME" to "DATE":
- Updated `headers` list (line 20)
- Updated column check in `toframe()` method (line 81)  
- Updated `set_index()` call (line 85)

## Testing
Tested successfully with multiple PSX stocks (GTYR, GAL, PAEL, PSO, PPL, SNGP, GHNI, PIOC, GLAXO, CPHL, LOTCHEM, MARI, ENGROH, EFERT, SHFA, CRTM, SLGL, FCEPL, DGKC, BIPL).

All stocks fetched successfully with the updated code.

## Impact
This fixes the broken library and makes it work with the current PSX website structure (as of October 2025).

## Changes Made
```python
# Before
headers = ['TIME', 'OPEN', 'HIGH', 'LOW', 'CLOSE', 'VOLUME']
if key == "TIME":
    value = datetime.strptime(value, "%b %d, %Y")
return pd.DataFrame(stocks, columns=self.headers).set_index("TIME")

# After  
headers = ['DATE', 'OPEN', 'HIGH', 'LOW', 'CLOSE', 'VOLUME']
if key == "DATE":
    value = datetime.strptime(value, "%b %d, %Y")
return pd.DataFrame(stocks, columns=self.headers).set_index("DATE")
```